### PR TITLE
Add missing table support

### DIFF
--- a/lyft_dataset_sdk/lyftdataset.py
+++ b/lyft_dataset_sdk/lyftdataset.py
@@ -34,7 +34,7 @@ if not PYTHON_VERSION == 3:
 class LyftDataset:
     """Database class for Lyft Dataset to help query and retrieve information from the database."""
 
-    def __init__(self, data_path: str, json_path: str, verbose: bool = True, map_resolution: float = 0.1):
+    def __init__(self, data_path: str, json_path: str, verbose: bool = True, map_resolution: float = 0.1, missing_tables_ok = False):
         """Loads database and creates reverse indexes and shortcuts.
 
         Args:
@@ -66,19 +66,19 @@ class LyftDataset:
         start_time = time.time()
 
         # Explicitly assign tables to help the IDE determine valid class members.
-        self.category = self.__load_table__("category")
-        self.attribute = self.__load_table__("attribute")
-        self.visibility = self.__load_table__("visibility")
-        self.instance = self.__load_table__("instance")
-        self.sensor = self.__load_table__("sensor")
-        self.calibrated_sensor = self.__load_table__("calibrated_sensor")
-        self.ego_pose = self.__load_table__("ego_pose")
-        self.log = self.__load_table__("log")
-        self.scene = self.__load_table__("scene")
-        self.sample = self.__load_table__("sample")
-        self.sample_data = self.__load_table__("sample_data")
-        self.sample_annotation = self.__load_table__("sample_annotation")
-        self.map = self.__load_table__("map")
+        self.category = self.__load_table__("category", verbose, missing_tables_ok)
+        self.attribute = self.__load_table__("attribute", verbose, missing_tables_ok)
+        self.visibility = self.__load_table__("visibility", verbose, missing_tables_ok)
+        self.instance = self.__load_table__("instance", verbose, missing_tables_ok)
+        self.sensor = self.__load_table__("sensor", verbose, missing_tables_ok)
+        self.calibrated_sensor = self.__load_table__("calibrated_sensor", verbose, missing_tables_ok)
+        self.ego_pose = self.__load_table__("ego_pose", verbose, missing_tables_ok)
+        self.log = self.__load_table__("log", verbose, missing_tables_ok)
+        self.scene = self.__load_table__("scene", verbose, missing_tables_ok)
+        self.sample = self.__load_table__("sample", verbose, missing_tables_ok)
+        self.sample_data = self.__load_table__("sample_data", verbose, missing_tables_ok)
+        self.sample_annotation = self.__load_table__("sample_annotation", verbose, missing_tables_ok)
+        self.map = self.__load_table__("map", verbose, missing_tables_ok)
 
         # Initialize map mask for each map record.
         for map_record in self.map:
@@ -95,9 +95,16 @@ class LyftDataset:
         # Initialize LyftDatasetExplorer class
         self.explorer = LyftDatasetExplorer(self)
 
-    def __load_table__(self, table_name) -> dict:
+    def __load_table__(self, table_name, verbose=False, missing_ok=False) -> dict:
         """Loads a table."""
-        with open(str(self.json_path.joinpath("{}.json".format(table_name)))) as f:
+        filepath = str(self.json_path.joinpath("{}.json".format(table_name))) 
+
+        if not os.path.isfile(filepath) and missing_ok:
+            if verbose:
+                print("JSON file {}.json missing, replacing table with empty dict".format(table_name))
+            return {}
+
+        with open(filepath) as f:
             table = json.load(f)
         return table
 

--- a/lyft_dataset_sdk/lyftdataset.py
+++ b/lyft_dataset_sdk/lyftdataset.py
@@ -34,7 +34,14 @@ if not PYTHON_VERSION == 3:
 class LyftDataset:
     """Database class for Lyft Dataset to help query and retrieve information from the database."""
 
-    def __init__(self, data_path: str, json_path: str, verbose: bool = True, map_resolution: float = 0.1, missing_tables_ok = False):
+    def __init__(
+        self,
+        data_path: str,
+        json_path: str,
+        verbose: bool = True,
+        map_resolution: float = 0.1,
+        missing_tables_ok=False,
+    ):
         """Loads database and creates reverse indexes and shortcuts.
 
         Args:
@@ -97,7 +104,7 @@ class LyftDataset:
 
     def __load_table__(self, table_name, verbose=False, missing_ok=False) -> dict:
         """Loads a table."""
-        filepath = str(self.json_path.joinpath("{}.json".format(table_name))) 
+        filepath = str(self.json_path.joinpath("{}.json".format(table_name)))
 
         if not os.path.isfile(filepath) and missing_ok:
             if verbose:

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ DESCRIPTION = "SDK for Lyft dataset."
 URL = "https://github.com/lyft/nuscenes-devkit"
 AUTHOR = "Vladimir Iglovikov"
 REQUIRES_PYTHON = ">=3.6.0"
-VERSION = "0.0.6"
+VERSION = "0.0.7"
 
 here = os.path.abspath(os.path.dirname(__file__))
 


### PR DESCRIPTION
Used for loading for instance the test set where not every table JSON file is present. It replaces the contents which are normally read with an empty dict.

When initializing a LyftDataset object you can now pass `missing_tables_ok=True` to enable this behaviour. 

