### PR TITLE
Fixes and improvements for video rendering

### DIFF
--- a/lyft_dataset_sdk/lyftdataset.py
+++ b/lyft_dataset_sdk/lyftdataset.py
@@ -533,9 +533,13 @@ class LyftDataset:
         verbose: bool = False,
     ) -> None:
         self.explorer.render_scene_channel(
-            scene_token=scene_token, channel=channel, freq=freq,
-            image_size=imsize, out_path=out_path,
-            interactive=interactive, verbose=verbose,
+            scene_token=scene_token,
+            channel=channel,
+            freq=freq,
+            image_size=imsize,
+            out_path=out_path,
+            interactive=interactive,
+            verbose=verbose,
         )
 
     def render_egoposes_on_map(self, log_location: str, scene_tokens: List = None, out_path: str = None) -> None:
@@ -1308,8 +1312,7 @@ class LyftDatasetExplorer:
 
         # Open CV init
         if interactive:
-            name = "{}: {} (Space to pause, ESC to exit)".format(
-                scene_rec["name"], channel)
+            name = "{}: {} (Space to pause, ESC to exit)".format(scene_rec["name"], channel)
             cv2.namedWindow(name)
             cv2.moveWindow(name, 0, 0)
 
@@ -1322,7 +1325,7 @@ class LyftDatasetExplorer:
         has_more_frames = True
         while has_more_frames:
             if verbose:
-                print(sd_rec['token'])
+                print(sd_rec["token"])
 
             # Get data from DB
             image_path, boxes, camera_intrinsic = self.lyftd.get_sample_data(

--- a/lyft_dataset_sdk/lyftdataset.py
+++ b/lyft_dataset_sdk/lyftdataset.py
@@ -1281,6 +1281,8 @@ class LyftDatasetExplorer:
             freq: Display frequency (Hz).
             image_size: Size of image to render. The larger the slower this will run.
             out_path: Optional path to write a video file of the rendered frames.
+            interactive: show video in a cv2 window (True by default).
+            verbose: set to True to print currently processed token.
 
         """
 


### PR DESCRIPTION
- add ``verbose`` and ``interactive`` arguments to ``render_scene_channel`` to allow rendering to the file without creating the window, and also printing currently processed tokens to make it visible that something is happening
- fix ``out_path`` type annotation
- fix saving cv2 video (first argument converted from path to string)